### PR TITLE
Update rustc-serialize dependency to version 0.3.24 (Fixes #30)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "rust-2048"
 path = "src/main.rs"
 
 [dependencies]
-rustc-serialize = "0.3"
+rustc-serialize = "0.3.24"
 rand = "0.3.7"
 piston_window = "0.61.0"
 pistoncore-sdl2_window = "0.38.0"


### PR DESCRIPTION
This is just an intermediate fix, since `rustc-serialize` has been deprecated in favor of `serde` (see https://crates.io/crates/rustc-serialize).
In the medium term we should switch to `serde`.

Fixes #30.