### PR TITLE
Replace rustc-serialize with serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,17 +1546,10 @@ dependencies = [
  "piston_window",
  "pistoncore-sdl2_window",
  "rand 0.3.23",
- "rustc-serialize",
  "serde",
  "serde_derive",
  "serde_json",
 ]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rusttype"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "cocoa-foundation"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
+checksum = "931d3837c286f56e3c58423ce4eba12d08db2374461a785c86f672b08b5650d6"
 dependencies = [
  "bitflags",
  "block",
@@ -750,6 +750,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jni-sys"
@@ -1541,6 +1547,9 @@ dependencies = [
  "pistoncore-sdl2_window",
  "rand 0.3.23",
  "rustc-serialize",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -1558,6 +1567,12 @@ dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -1611,19 +1626,30 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.155"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f2b4817415c6d4210bfe1c7bfcf4801b2d904cb4d0e1a8fdb651013c9e86b8"
+checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.155"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d071a94a3fac4aff69d023a7f411e33f40f3483f8c5190b1953822b6b76d7630"
+checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1790,12 +1816,11 @@ checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
  "winapi-util",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,10 @@ name = "rust-2048"
 path = "src/main.rs"
 
 [dependencies]
-rustc-serialize = "0.3"
+rustc-serialize = "0.3.24"
+serde = "1.0.79"
+serde_json = "1.0.27"
+serde_derive = "1.0.79"
 rand = "0.3.7"
 piston_window = "0.127.0"
 pistoncore-sdl2_window = "0.68.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ name = "rust-2048"
 path = "src/main.rs"
 
 [dependencies]
-rustc-serialize = "0.3.24"
 serde = "1.0.79"
 serde_json = "1.0.27"
 serde_derive = "1.0.79"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 extern crate serde_derive;
-extern crate rustc_serialize;
 extern crate rand;
 extern crate piston_window;
 extern crate opengl_graphics;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+extern crate serde_derive;
 extern crate rustc_serialize;
 extern crate rand;
 extern crate piston_window;


### PR DESCRIPTION
This change is the same as #32, but rebased onto #40.
It no longer fixes a build failure, but I left the commit messages unchanged.